### PR TITLE
Target recent history plugin to Net Standard 2.1

### DIFF
--- a/src/Quartz.Plugins.RecentHistory/Quartz.Plugins.RecentHistory.csproj
+++ b/src/Quartz.Plugins.RecentHistory/Quartz.Plugins.RecentHistory.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <TargetFrameworks>netcoreapp3.1;net5</TargetFrameworks>
+	  <TargetFrameworks>netstandard2.1</TargetFrameworks>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
     <GeneratePackageOnBuild Condition="'$(Configuration)' == 'Release'">true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
### Overview:
This PR aimed target `Quartz.Plugins.RecentHistory` assembly to net standard 2.1.
It help in clustering use case where we have various project that spread out all from .net core 2.1 to 5.0.
Despite we cant take management UI to each project but can still centralize manage them through dedicate managed standby node, cover the history infor since all below 3.1 environment project can apply `Quartz.Plugins.RecentHistory` now.