### PR TITLE
Fix version conflicts caused by PR#99

### DIFF
--- a/src/SilkierQuartz/SilkierQuartz.csproj
+++ b/src/SilkierQuartz/SilkierQuartz.csproj
@@ -46,13 +46,13 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net5'">
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.5" />
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="5.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.8" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="5.0.8" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="5.0.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="5.0.5" />
-		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="5.0.5" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.17" />
+		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.17" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.10" />
 	</ItemGroup>
 


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.AspNetCore.Mvc.NewtonsoftJson from 5.0.5 to 5.0.8. [(PR#99)](https://github.com/maikebing/SilkierQuartz/pull/99).
Hope this fix can help you.

Best regards,
sucrose