### PR TITLE
Fixing Cookie path

### DIFF
--- a/src/SilkierQuartz/Configuration/ServiceCollectionExtensions.cs
+++ b/src/SilkierQuartz/Configuration/ServiceCollectionExtensions.cs
@@ -32,14 +32,16 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(authenticationOptions);
             if (authenticationOptions.AccessRequirement != SilkierQuartzAuthenticationOptions.SimpleAccessRequirement.AllowAnonymous)
             {
+                var normalizedVirtualPath = $"{options.VirtualPathRoot}{(options.VirtualPathRoot.EndsWith('/') ? "" : "/")}";
+                var cookiePath = $"{options.BasePath}{(options.BasePath.EndsWith('/') ? "" : "/")}{normalizedVirtualPath.Trim('/')}";
                 services
                     .AddAuthentication(authenticationOptions.AuthScheme)
                     .AddCookie(authenticationOptions.AuthScheme, cfg =>
                     {
                         cfg.Cookie.Name = authenticationOptions.CookieName;
-                        cfg.Cookie.Path = options.VirtualPathRoot;
-                        cfg.LoginPath = $"{options.VirtualPathRoot}{(options.VirtualPathRoot.EndsWith('/') ? "" : "/")}Authenticate/Login";
-                        cfg.AccessDeniedPath = $"{options.VirtualPathRoot}{(options.VirtualPathRoot.EndsWith('/') ? "" : "/")}Authenticate/Login";
+                        cfg.Cookie.Path = cookiePath;
+                        cfg.LoginPath = $"{normalizedVirtualPath}Authenticate/Login";
+                        cfg.AccessDeniedPath = $"{normalizedVirtualPath}Authenticate/Login";
                         cfg.ExpireTimeSpan = TimeSpan.FromDays(7);
                         cfg.SlidingExpiration = true;
                     });


### PR DESCRIPTION
I noticed that after removing my custom bindings I had made long time ago and switching fully to using `AddSilkierQuartz` middleware the authentication stopped working for me in production.
 
It seems like:
* if base path is "/", then Cookie is set to "/quartz". That works, as entire app is hosted under "/quartz"
* if base path is set to "/whatever" then app is offset and hosted under "/whatever/quartz", but the cookie is still set to "/quartz"

That clearly can't work. In this PR I've been trying to fix it.
 